### PR TITLE
Remove lantern fires

### DIFF
--- a/config/supplementaries-common.toml
+++ b/config/supplementaries-common.toml
@@ -305,7 +305,7 @@
 		mod_blacklist = ["extlights", "betterendforge", "tconstruct", "enigmaticlegacy"]
 		#Allows ceiling lanterns to fall if their support is broken.Additionally if they fall from high enough they will break creating a fire where they land
 		#Allowed Values: ON, OFF, NO_FIRE
-		fallin_lanterns = "ON"
+		fallin_lanterns = "OFF"
 
 	[tweaks.bells_tweaks]
 		#Ring a bell by clicking on a chain that's connected to it


### PR DESCRIPTION
Minecolonies builders knock down lanterns when upgrading buildings. This interacts poorly with Supplementaries Tweaks causing lantern fires, which can then burn down the building.